### PR TITLE
Introduce inhouse rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem "resque", "~> 1.25.0"
 gem "resque-scheduler"
 gem "resque-sentry"
 gem "rubocop", "0.29.1"
+gem "rubocop-bitjourney", github: "bitjourney/rubocop-bitjourney"
+gem "rubocop-rspec"
 gem "sass-rails"
 gem "scss-lint", "0.34.0", require: false
 gem "split", require: "split/dashboard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -387,3 +387,6 @@ DEPENDENCIES
   uglifier (>= 1.0.3)
   unicorn
   webmock
+
+BUNDLED WITH
+   1.10.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,10 @@
 GIT
+  remote: git://github.com/bitjourney/rubocop-bitjourney.git
+  revision: 400feefd1001ba3de570d0fd53c0002c89f43550
+  specs:
+    rubocop-bitjourney (0.1.0)
+
+GIT
   remote: git://github.com/octokit/octokit.rb.git
   revision: 703d8587665e8ed6279847a69095f79996b027ec
   specs:
@@ -267,6 +273,7 @@ GEM
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.4)
+    rubocop-rspec (1.3.0)
     ruby-progressbar (1.7.1)
     rufus-scheduler (3.0.9)
       tzinfo
@@ -378,6 +385,8 @@ DEPENDENCIES
   resque-sentry
   rspec-rails (>= 3.2)
   rubocop (= 0.29.1)
+  rubocop-bitjourney!
+  rubocop-rspec
   sass-rails
   scss-lint (= 0.34.0)
   sentry-raven


### PR DESCRIPTION
Install `rubocop-bitjourney` and `rubocop-rspec` to hound
